### PR TITLE
Updated version in README to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Since it is unofficial, don't expect any support, bug fixes or updates in any so
 Add the following dependency to `build.sbt`:
 
 ```scala
-"com.typesafe.play.extras" %% "play-geojson" % "1.0.0"
+"com.typesafe.play.extras" %% "play-geojson" % "1.1.0"
 ```
 
 ## Usage instructions


### PR DESCRIPTION
Just happened to notice the version in the readme doesn't match the latest release (1.1.0).
