### PR TITLE
Adding SphericalMercator into standard lib with conversions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ name := "play-geojson"
 
 version := "1.1.0"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.4"
 
-crossScalaVersions := Seq("2.11.1", "2.10.4")
+crossScalaVersions := Seq("2.11.4", "2.10.4")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.3.0-RC2" % "provided",
+  "com.typesafe.play" %% "play-json" % "2.3.7" % "provided",
   "org.specs2" %% "specs2" % "2.3.12" %  "test"
 )
 

--- a/src/main/scala/play/extras/geojson/GeoJson.scala
+++ b/src/main/scala/play/extras/geojson/GeoJson.scala
@@ -212,19 +212,6 @@ object LinkedCrs {
 }
 
 /**
- * A latitude longitude CRS, for use with WGS84.
- *
- * @param lat The latitude.
- * @param lng The longitude.
- */
-case class LatLng(lat: Double, lng: Double)
-
-object LatLng {
-  implicit val latLngFormat: Format[LatLng] = Wgs84Format.format
-  implicit val latLngCrs: CrsFormat[LatLng] = Wgs84Format
-}
-
-/**
  * A CRS format
  */
 trait CrsFormat[C] {
@@ -245,19 +232,6 @@ trait CrsFormat[C] {
   def isDefault = false
 }
 
-/**
- * The WGS84 CRS format.
- */
-object Wgs84Format extends CrsFormat[LatLng] {
-  val crs = NamedCrs("urn:ogc:def:crs:OGC:1.3:CRS84")
-  val format = Format[LatLng](
-    __.read[Seq[Double]].map {
-      case Seq(lng, lat) => LatLng(lat, lng)
-    }, Writes(latLng => Json.arr(latLng.lng, latLng.lat))
-  )
-
-  override def isDefault = true
-}
 
 /**
  * These are the raw "internal" formats.  They do not add the CRS parameter when serialising.

--- a/src/main/scala/play/extras/geojson/LatLng.scala
+++ b/src/main/scala/play/extras/geojson/LatLng.scala
@@ -1,0 +1,33 @@
+package play.extras.geojson
+
+import scala.collection.immutable.Seq
+import play.api.libs.json._
+import play.api.libs.functional._
+import play.api.libs.functional.syntax._
+
+/**
+ * A latitude longitude CRS, for use with WGS84 ( == EPSG:4326).
+ *
+ * @param lat The latitude.
+ * @param lng The longitude.
+ */
+case class LatLng(lat: Double, lng: Double)
+
+object LatLng {
+  implicit val latLngFormat: Format[LatLng] = Wgs84Format.format
+  implicit val latLngCrs: CrsFormat[LatLng] = Wgs84Format
+}
+
+/**
+ * The WGS84 CRS format. Equals to EPSG:4326 CRS format.
+ */
+object Wgs84Format extends CrsFormat[LatLng] {
+  val crs = NamedCrs("urn:ogc:def:crs:OGC:1.3:CRS84")
+  val format = Format[LatLng](
+    __.read[Seq[Double]].map {
+      case Seq(lng, lat) => LatLng(lat, lng)
+    }, Writes(latLng => Json.arr(latLng.lng, latLng.lat))
+  )
+
+  override def isDefault = true
+}

--- a/src/main/scala/play/extras/geojson/SphericalMercator.scala
+++ b/src/main/scala/play/extras/geojson/SphericalMercator.scala
@@ -1,0 +1,66 @@
+package play.extras.geojson
+
+import play.api.libs.json._
+import scala.math._
+import play.api.libs.json.Json.toJsFieldJsValueWrapper
+
+case class SphericalMercator(x: Double, y: Double)
+
+/**
+ * Code is partially translated from the OpenLayers.js project.
+ *
+ * @see https://github.com/openlayers/ol3/blob/master/src/ol/proj/epsg3857projection.js
+ */
+object SphericalMercator {
+  implicit val format: Format[SphericalMercator] = SphericalMercatorCrs.format
+  implicit val crs: CrsFormat[SphericalMercator] = SphericalMercatorCrs
+
+  /** earth radius in meter */
+  val RADIUS = 6378137
+  
+  /** pre calculated earthradius * PI */
+  val HALF_SIZE = Pi * RADIUS
+
+  val EXTENT = List(
+    -HALF_SIZE, -HALF_SIZE, HALF_SIZE, HALF_SIZE
+  )
+
+  val WORLD_EXTENT = List(-180, -85, 180, 85)
+
+  /**
+   * Transformation from EPSG:4326 to EPSG:3857
+   * 
+   * @param input in LatLng format
+   * @param factor, default is earth radius in meter
+   * @return EPSG:3857/SphericalMercator projection
+   */
+  def fromEPSG4326(input: LatLng, factor: Double = RADIUS): SphericalMercator = {
+    val y = factor * log(tan(Pi * (input.lat + 90) / 360))
+    val x = factor * Pi * input.lng / 180
+
+    SphericalMercator(x, y)
+  }
+
+  /**
+   * Transformation from EPSG:3857 to EPSG:4326
+   * 
+   * @param input in EPSG:3857/SphericalMercator format
+   * @param factor, default is earth radius in meter
+   * @return LatLng in EPSG4326 format
+   */
+  def toEPSG4326(input: SphericalMercator, factor: Double = RADIUS): LatLng = {
+    val lat = 360 * atan(exp(input.y / factor)) / Pi - 90
+    val lng = 180 * input.x / (factor * Pi)
+    LatLng(lat, lng)
+  }
+
+}
+
+object SphericalMercatorCrs extends CrsFormat[SphericalMercator] {
+  val crs = NamedCrs("urn:ogc:def:crs:EPSG::3857")
+  val format = Format[SphericalMercator](
+    __.read[Seq[Int]].map {
+      case Seq(x, y) => SphericalMercator(x, y)
+    }, Writes(m => Json.arr(m.x, m.y))
+  )
+}

--- a/src/test/scala/play/extras/geojson/SphericalMercatorSpec.scala
+++ b/src/test/scala/play/extras/geojson/SphericalMercatorSpec.scala
@@ -1,0 +1,39 @@
+package play.extras.geojson
+
+import scala.collection.immutable.Seq
+import org.specs2.mutable.Specification
+import play.api.libs.json._
+
+class DistancesTest extends Specification {
+
+  "SphericalMercator.fromEPSG4326" should {
+
+    "return LatLng(1290504.0696666553, 6132301.564388968)" in {
+      val epsg3857 = SphericalMercator.fromEPSG4326(LatLng(48.1527311, 11.5927953))
+      epsg3857.x should be ~(1290504.0696666553 +/- 0.00000001)
+      epsg3857.y should be ~(6132301.564388968 +/- 0.00000001)
+    }
+
+    "return LatLng(1289983.283692877, 6131013.827170381)" in {
+      val epsg3857 = SphericalMercator.fromEPSG4326(LatLng(48.145013, 11.588117))
+      epsg3857.x should be ~(1289983.283692877 +/- 0.00000001)
+      epsg3857.y should be ~(6131013.827170381 +/- 0.00000001)
+    }
+  }
+
+  "SphericalMercator.toEPSG4326" should {
+    "return LatLng(48.1527311, 11.5927953)" in {
+      val epsg4326 = SphericalMercator.toEPSG4326(SphericalMercator(1290504.0696666553, 6132301.564388968))
+      epsg4326.lat should be ~(48.1527311 +/- 0.00000001)
+      epsg4326.lng should be ~(11.59279530 +/- 0.00000001)
+    }
+
+    "return LatLng(48.145013, 11.588117)" in {
+      val epsg4326 = SphericalMercator.toEPSG4326(SphericalMercator(1289983.283692877, 6131013.827170381))
+      epsg4326.lat should be ~(48.145013 +/- 0.00000001)
+      epsg4326.lng should be ~(11.588117 +/- 0.00000001)
+
+    }
+  }
+
+}


### PR DESCRIPTION
- Upgrade to play `2.3.7`
- Refactor `LatLng`
- Added `SphericalMercator` from Tests to standard lib
- Added conversions from `LatLng` to `SphericalMercator`

Tested with OpenLayers v.3.1.1.
