### PR TITLE
Ensure compatibility with Play 2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion := "2.11.6"
 crossScalaVersions := Seq("2.11.6", "2.10.4")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-json" % "2.4.0" % "provided",
+  "com.typesafe.play" %% "play-json" % "2.4.2" % "provided",
   "org.specs2" %% "specs2-core" % "3.4" %  "test"
 )
 

--- a/src/main/scala/play/extras/geojson/GeoJson.scala
+++ b/src/main/scala/play/extras/geojson/GeoJson.scala
@@ -274,7 +274,7 @@ private object GeoFormats {
    * If the type is not the given name, a validation error is thrown.
    */
   def filterType(geoJsonType: String): Reads[String] =
-    readType.filter(new ValidationError(Seq("Geometry is not a " + geoJsonType)))(_ == geoJsonType)
+    readType.filter(ValidationError("Geometry is not a " + geoJsonType))(_ == geoJsonType)
 
   /**
    * Writes for the GeoJSON type property for the given type.


### PR DESCRIPTION
Fixes #13

This should also be binary compatible with Play 2.3, since ValidationError.apply(message: String, args: Any*) exists on both Play 2.4 and Play 2.3.
