### PR TITLE
Parse doubles instead of ints

### DIFF
--- a/src/main/scala/play/extras/geojson/SphericalMercator.scala
+++ b/src/main/scala/play/extras/geojson/SphericalMercator.scala
@@ -59,7 +59,7 @@ object SphericalMercator {
 object SphericalMercatorCrs extends CrsFormat[SphericalMercator] {
   val crs = NamedCrs("urn:ogc:def:crs:EPSG::3857")
   val format = Format[SphericalMercator](
-    __.read[Seq[Int]].map {
+    __.read[Seq[Double]].map {
       case Seq(x, y) => SphericalMercator(x, y)
     }, Writes(m => Json.arr(m.x, m.y))
   )


### PR DESCRIPTION
This causes parse errors when the precision is better.
